### PR TITLE
Support fwupdate upgrade local_file

### DIFF
--- a/board/common/overlay/sbin/fwupdate
+++ b/board/common/overlay/sbin/fwupdate
@@ -112,6 +112,26 @@ function do_download() {
     rm -f $FW_DIR/$FW_FILE_GZ $FW_DIR/$FW_FILE_XZ
     rm -f $FW_DIR/$FW_FILE_EXTR
     rm -f $FW_DIR/$BOOT_READY_FILE
+    rm -rf $FW_DIR/*
+    mkdir -p $FW_DIR
+
+	# Look for local file first
+    if [ -f "$1" ]; then
+        version="custom"
+        FNAME=`basename $1`
+        FILEEXT=${FNAME##*.}
+		DST_FNAME=""
+        if [ "$FILEEXT" == "xz" ]; then
+            DST_FNAME="$FW_DIR/$FW_FILE_XZ"
+        elif [ "$FILEEXT" == "gz" ]; then
+            DST_FNAME="$FW_DIR/$FW_FILE_GZ"
+        fi
+		if [ -n "$DST_FNAME" ]; then
+            cp -f $1 $DST_FNAME
+			echo $version > $FW_DIR/$VER_FILE
+			return
+		fi
+    fi
 
     source $OS_CONF
     board=$(cat $SYS_BOARD_FILE)
@@ -141,8 +161,6 @@ function do_download() {
         outfile=$FW_DIR/$FW_FILE_XZ
     fi
 
-    rm -rf $FW_DIR/*
-    mkdir -p $FW_DIR
     echo $version > $FW_DIR/$VER_FILE
 
     curl_opts="-S -f -L"

--- a/board/common/overlay/sbin/fwupdate
+++ b/board/common/overlay/sbin/fwupdate
@@ -109,9 +109,6 @@ function show_current() {
 function do_download() {
     echo "downloading..."
 
-    rm -f $FW_DIR/$FW_FILE_GZ $FW_DIR/$FW_FILE_XZ
-    rm -f $FW_DIR/$FW_FILE_EXTR
-    rm -f $FW_DIR/$BOOT_READY_FILE
     rm -rf $FW_DIR/*
     mkdir -p $FW_DIR
 

--- a/board/common/overlay/sbin/fwupdate
+++ b/board/common/overlay/sbin/fwupdate
@@ -115,22 +115,22 @@ function do_download() {
     rm -rf $FW_DIR/*
     mkdir -p $FW_DIR
 
-	# Look for local file first
+    # Look for local file first
     if [ -f "$1" ]; then
         version="custom"
         FNAME=`basename $1`
         FILEEXT=${FNAME##*.}
-		DST_FNAME=""
+        DST_FNAME=""
         if [ "$FILEEXT" == "xz" ]; then
             DST_FNAME="$FW_DIR/$FW_FILE_XZ"
         elif [ "$FILEEXT" == "gz" ]; then
             DST_FNAME="$FW_DIR/$FW_FILE_GZ"
         fi
-		if [ -n "$DST_FNAME" ]; then
+        if [ -n "$DST_FNAME" ]; then
             cp -f $1 $DST_FNAME
-			echo $version > $FW_DIR/$VER_FILE
-			return
-		fi
+            echo $version > $FW_DIR/$VER_FILE
+            return
+        fi
     fi
 
     source $OS_CONF


### PR DESCRIPTION
Enable `fwupdate upgrade <local_file>` command.
If local file exists, fwupdate will upgrade using the local file, otherwise it will download firmware like before.

Original issue here: https://github.com/ccrisan/motioneyeos/issues/1746