### PR TITLE
AWB Greyworld mode to picamera and motion

### DIFF
--- a/package/libv4l/libv4l.hash
+++ b/package/libv4l/libv4l.hash
@@ -1,6 +1,6 @@
 # Locally calculated after checking signature
 # https://linuxtv.org/downloads/v4l-utils/v4l-utils-1.16.3.tar.bz2.asc
-sha256 7c5c0d49c130cf65d384f28e9f3a53c5f7d17bf18740c48c40810e0fbbed5b54  v4l-utils-1.16.3.tar.bz2
+sha256 f9dac1878e3d5636eab7f56bb209fdfc66b94ee8a2aae54dcb4282fe63a678ae  v4l-utils-1.16.6.tar.bz2
 # Locally calculated
 sha256 391e4da1c54a422a78d83be7bf84b2dfb8bacdd8ad256fa4374e128655584a8a  COPYING
 sha256 5a7f623a50e384aaf6d2ced068339ddf93d0a50d3a0ecbe86f125b07804ecc78  COPYING.libv4l

--- a/package/libv4l/libv4l.mk
+++ b/package/libv4l/libv4l.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-LIBV4L_VERSION = 1.16.3
+LIBV4L_VERSION = 1.16.6
 LIBV4L_SOURCE = v4l-utils-$(LIBV4L_VERSION).tar.bz2
 LIBV4L_SITE = https://linuxtv.org/downloads/v4l-utils
 LIBV4L_INSTALL_STAGING = YES

--- a/package/motion/0001-enable-awb-greyworld.patch
+++ b/package/motion/0001-enable-awb-greyworld.patch
@@ -1,0 +1,35 @@
+diff --git a/raspicam/RaspiCamControl.c b/raspicam/RaspiCamControl.c
+index 073d657..ad0e405 100644
+--- a/raspicam/RaspiCamControl.c
++++ b/raspicam/RaspiCamControl.c
+@@ -73,7 +73,8 @@ static XREF_T awb_map[] =
+    {"fluorescent",   MMAL_PARAM_AWBMODE_FLUORESCENT},
+    {"incandescent",  MMAL_PARAM_AWBMODE_INCANDESCENT},
+    {"flash",         MMAL_PARAM_AWBMODE_FLASH},
+-   {"horizon",       MMAL_PARAM_AWBMODE_HORIZON}
++   {"horizon",       MMAL_PARAM_AWBMODE_HORIZON},
++   {"greyworld",     MMAL_PARAM_AWBMODE_GREYWORLD}
+ };
+ 
+ static const int awb_map_size = sizeof(awb_map) / sizeof(awb_map[0]);
+@@ -1196,6 +1197,7 @@ int raspicamcontrol_set_exposure_mode(MMAL_COMPONENT_T *camera, MMAL_PARAM_EXPOS
+  *   - MMAL_PARAM_AWBMODE_INCANDESCENT,
+  *   - MMAL_PARAM_AWBMODE_FLASH,
+  *   - MMAL_PARAM_AWBMODE_HORIZON,
++ *   - MMAL_PARAM_AWBMODE_GREYWORLD,
+  * @return 0 if successful, non-zero if any parameters out of range
+  */
+ int raspicamcontrol_set_awb_mode(MMAL_COMPONENT_T *camera, MMAL_PARAM_AWBMODE_T awb_mode)
+diff --git a/raspicam/RaspiCamControl.h b/raspicam/RaspiCamControl.h
+index f4c189a..e7a847f 100644
+--- a/raspicam/RaspiCamControl.h
++++ b/raspicam/RaspiCamControl.h
+@@ -57,6 +57,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+             MMAL_PARAM_AWBMODE_INCANDESCENT,
+             MMAL_PARAM_AWBMODE_FLASH,
+             MMAL_PARAM_AWBMODE_HORIZON,
++            MMAL_PARAM_AWBMODE_GREYWORLD,
+  *
+  * Image FX
+             MMAL_PARAM_IMAGEFX_NONE,
+

--- a/package/python-picamera/0001-enable-awb-greyworld-mode.patch
+++ b/package/python-picamera/0001-enable-awb-greyworld-mode.patch
@@ -1,0 +1,27 @@
+diff --git a/picamera/camera.py b/picamera/camera.py
+index 36b1202..a7da186 100644
+--- a/picamera/camera.py
++++ b/picamera/camera.py
+@@ -274,6 +274,7 @@ class PiCamera(object):
+         'incandescent':  mmal.MMAL_PARAM_AWBMODE_INCANDESCENT,
+         'flash':         mmal.MMAL_PARAM_AWBMODE_FLASH,
+         'horizon':       mmal.MMAL_PARAM_AWBMODE_HORIZON,
++        'greyworld':     mmal.MMAL_PARAM_AWBMODE_GREYWORLD,
+         }
+
+     IMAGE_EFFECTS = {
+diff --git a/picamera/mmal.py b/picamera/mmal.py
+index 81b059f..82b2b5f 100644
+--- a/picamera/mmal.py
++++ b/picamera/mmal.py
+@@ -692,7 +692,8 @@ MMAL_PARAM_AWBMODE_T = ct.c_uint32 # enum
+     MMAL_PARAM_AWBMODE_INCANDESCENT,
+     MMAL_PARAM_AWBMODE_FLASH,
+     MMAL_PARAM_AWBMODE_HORIZON,
+-) = range(10)
++    MMAL_PARAM_AWBMODE_GREYWORLD,
++) = range(11)
+ MMAL_PARAM_AWBMODE_MAX = 0x7fffffff
+
+ class MMAL_PARAMETER_AWBMODE_T(ct.Structure):
+


### PR DESCRIPTION
These are simple patches for python-picamera and motion to account for the extra AWB mode developed in latest kernels.
- raspimjpeg.py in streameye (only used by MJPEG FNC) must also be updated, but this is needed in picamera first. There is a PR upstream but is unclear how long will take to implement. Maybe that project is dead.
- motion: this is a simple patch for the userland files to recognize the new AWB instruction when parsed via "Extra Motion Options". The command is `mmalcam_control_params -awb greyworld`. Patch does not influence the way motion works in any way.
- v4l-utils update is actually not needed. I thought it might have been updated to allow an additional num in v4l2 AWB.

with AWB Auto:
![image](https://user-images.githubusercontent.com/5729304/63151475-1ca75100-bff9-11e9-98d2-c2d23649352b.png)
with AWB Greyworld
![image](https://user-images.githubusercontent.com/5729304/63151495-2af56d00-bff9-11e9-828c-e2d6018fac02.png)
