### PR TITLE
rpi-userland: remove missing apps

### DIFF
--- a/package/rpi-userland/0005-disable-missing-all-apps.patch
+++ b/package/rpi-userland/0005-disable-missing-all-apps.patch
@@ -1,0 +1,14 @@
+diff -rupEbBN rpi-userland-org/host_applications/linux/CMakeLists.txt rpi-userland-d574b51a60a075baefe863670466ee24e6c4256e/host_applications/linux/CMakeLists.txt
+--- rpi-userland-org/host_applications/linux/CMakeLists.txt	2018-12-04 16:02:51.189384113 +1100
++++ rpi-userland-d574b51a60a075baefe863670466ee24e6c4256e/host_applications/linux/CMakeLists.txt	2018-12-04 16:08:25.363548444 +1100
+@@ -14,10 +14,5 @@ add_subdirectory(apps/dtoverlay)
+ add_subdirectory(apps/dtmerge)
+ 
+ if(ALL_APPS)
+- add_subdirectory(apps/vcdbg)
+- add_subdirectory(libs/elftoolchain)
+- # add_subdirectory(apps/smct)
+- add_subdirectory(apps/edid_parser)
+  add_subdirectory(apps/hello_pi)
+ endif()
+-


### PR DESCRIPTION
Remove references to rpi-userland missing programs that causes build to fail.