### PR TITLE
fix fwupdate when upgrading from local images

### DIFF
--- a/board/common/overlay/sbin/fwupdate
+++ b/board/common/overlay/sbin/fwupdate
@@ -275,6 +275,7 @@ function do_download() {
         if [[ -n "${DST_FNAME}" ]]; then
             cp -f $1 ${DST_FNAME}
             echo ${version} > ${VER_FILE}
+            touch ${DOWNLOAD_DONE_FILE}
             return
         fi
     fi


### PR DESCRIPTION
Upgrading from local files exits without touching ${DOWNLOAD_DONE_FILE}.