### PR TITLE
Trigger udev usb-storage rules only if device is added

### DIFF
--- a/board/common/overlay/etc/udev/rules.d/61-usb-storage.rules
+++ b/board/common/overlay/etc/udev/rules.d/61-usb-storage.rules
@@ -1,2 +1,2 @@
-SUBSYSTEMS=="scsi", ENV{ID_FS_TYPE}=="vfat|ext2|ext3|ext4" RUN+="/bin/mkdir -p /data/media/%k", RUN+="/bin/mount /dev/%k /data/media/%k"
-SUBSYSTEMS=="scsi", ENV{ID_FS_TYPE}=="ntfs" RUN+="/bin/mkdir -p /data/media/%k", RUN+="/usr/bin/ntfs-3g /dev/%k /data/media/%k"
+SUBSYSTEMS=="scsi", ACTION=="add", ENV{ID_FS_TYPE}=="vfat|ext2|ext3|ext4" RUN+="/bin/mkdir -p /data/media/%k", RUN+="/bin/mount /dev/%k /data/media/%k"
+SUBSYSTEMS=="scsi", ACTION=="add", ENV{ID_FS_TYPE}=="ntfs" RUN+="/bin/mkdir -p /data/media/%k", RUN+="/usr/bin/ntfs-3g /dev/%k /data/media/%k"


### PR DESCRIPTION
Currently, the udev rules are triggerd twice on inserting and removing the stick. As the mount
command should not be triggered on remove, the rule has to be changed.

This can be checked by
* Inserting USB stick
* _/data/media/sda1 is created and stick is mounted_
* umount /data/media/sda1
* rmdir /data/media/sda1
* Remove USB stick
* _/data/media/sda1 is again created_