### PR TITLE
UDEV rule to clean up after an USB stick is removed

### DIFF
--- a/board/common/overlay/etc/udev/rules.d/61-usb-storage.rules
+++ b/board/common/overlay/etc/udev/rules.d/61-usb-storage.rules
@@ -1,2 +1,4 @@
 SUBSYSTEMS=="scsi", ACTION=="add", ENV{ID_FS_TYPE}=="vfat|ext2|ext3|ext4" RUN+="/bin/mkdir -p /data/media/%k", RUN+="/bin/mount /dev/%k /data/media/%k"
+SUBSYSTEMS=="scsi", ACTION=="remove", ENV{ID_FS_TYPE}=="vfat|ext2|ext3|ext4" RUN+="/bin/umount /data/media/%k" RUN+="/bin/rmdir /data/media/%k"
 SUBSYSTEMS=="scsi", ACTION=="add", ENV{ID_FS_TYPE}=="ntfs" RUN+="/bin/mkdir -p /data/media/%k", RUN+="/usr/bin/ntfs-3g /dev/%k /data/media/%k"
+SUBSYSTEMS=="scsi", ACTION=="remove", ENV{ID_FS_TYPE}=="ntfs" RUN+="/bin/umount /data/media/%k" RUN+="/bin/rmdir /data/media/%k"


### PR DESCRIPTION
If an USB stick is removed without manually unmounting, the device is till listed
as mounted and the mount folder also exists. If reinserting the USB stick, a new
mount folder is created. To avoid this behaviour, an additional rule is added to
clean things up.