### PR TITLE
Start dbus for connman

### DIFF
--- a/board/common/overlay/etc/init.d/S30dbus
+++ b/board/common/overlay/etc/init.d/S30dbus
@@ -3,6 +3,7 @@
 SYS_BTCONF="/etc/bluetooth.conf"
 BOOT_BTCONF="/boot/bluetooth.conf"
 BTCONF="/data/etc/bluetooth.conf"
+CMCONF="/etc/connman/main.conf"
 
 PROG="/usr/bin/dbus-daemon"
 PROG_UG="/usr/bin/dbus-uuidgen"
@@ -11,8 +12,8 @@ PROG_UA="/usr/bin/udevadm"
 
 test -x ${PROG} || exit 0
 
-# dbus is currently only used by bluez
-test -s ${BTCONF} || test -s ${BOOT_BTCONF} || test -s ${SYS_BTCONF} || exit 0
+# dbus is currently only used by bluez and connman
+test -s ${BTCONF} || test -s ${BOOT_BTCONF} || test -s ${SYS_BTCONF} || test -s ${CMCONF} || exit 0
 
 test -n "${OS_VERSION}" || source /etc/init.d/base
 


### PR DESCRIPTION
Connman itself requires dbus. Currently, dbus is started only when bluetooth is configured. In setups that use connman, but not bluetooth (e.g. for connecting wifi or ethernet), dbus wasn't started, preventing start of connman.