### PR TITLE
fwupdate: Fix post-upgrade version check

### DIFF
--- a/board/common/overlay/etc/init.d/S14postupgrade
+++ b/board/common/overlay/etc/init.d/S14postupgrade
@@ -36,7 +36,7 @@ function version_gt() {
     v1=$(echo ${v1[@]} | tr ' ' '.')
     v2=$(echo ${v2[@]} | tr ' ' '.')
 
-    if [[ "${v1}" != "${v2}" ]] && [[ $(echo -e "${v1}\n${v2}" | semver-sort | head -n 1) == "${v2}" ]]; then
+    if [[ "${v1}" != "${v2}" ]] && [[ $(echo -e "${v1}\n${v2}" | semver-sort 2>/dev/null | head -n 1) == "${v2}" ]]; then
         return 0
     else
         return 1
@@ -54,7 +54,13 @@ function run_post_upgrade() {
     
     versions=$(ls -1 ${POST_UPGRADE_DIR} | rev | cut -d '.' -f 2-100 | rev)
     for v in ${versions}; do
-        if [[ ${v} == "post-upgrade" ]]; then
+        # Skip post-upgrade* scripts as they are treated separately.
+        if [[ ${v} == post-upgrade* ]]; then
+            continue
+        fi
+
+        # Don't run scripts for previous (or current) versions.
+        if [[ -n "${version}" ]] && ! version_gt ${v} ${version}; then
             continue
         fi
 
@@ -68,11 +74,9 @@ function run_post_upgrade() {
             continue
         fi
     
-        if [[ -z "${version}" ]] || version_gt ${v} ${version}; then
-            msg_begin "Post-upgrading to version ${v}"
-            ${POST_UPGRADE_DIR}/${v}.sh >> ${LOG} 2>&1
-            test $? == 0 && msg_done || msg_fail
-        fi
+        msg_begin "Running post-upgrade script for version ${v}"
+        ${POST_UPGRADE_DIR}/${v}.sh >> ${LOG} 2>&1
+        test $? == 0 && msg_done || msg_fail
     done
     
     if [[ -x "${POST_UPGRADE_DIR}/post-upgrade.sh" ]]; then

--- a/board/common/overlay/etc/init.d/S52postupgradenet
+++ b/board/common/overlay/etc/init.d/S52postupgradenet
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+POST_UPGRADE_DIR="/usr/share/post-upgrade"
 POST_UPGRADE_NET_SCHEDULED="/data/.post-upgrade-net-scheduled"
 
 LOG="/var/log/post-upgrade.log"
@@ -7,7 +8,7 @@ LOG="/var/log/post-upgrade.log"
 
 test -n "${OS_VERSION}" || source /etc/init.d/base
 
-test -s ${POST_UPGRADE_NET_SCHEDULED} || exit 0
+test -f ${POST_UPGRADE_NET_SCHEDULED} || exit 0
 
 function run_post_upgrade() {
     for script in $(cat ${POST_UPGRADE_NET_SCHEDULED}); do
@@ -15,6 +16,12 @@ function run_post_upgrade() {
         ${script} >> ${LOG} 2>&1
         test $? == 0 && msg_done || msg_fail
     done
+
+    if [[ -x "${POST_UPGRADE_DIR}/post-upgrade-net.sh" ]]; then
+        msg_begin "Running common post-upgrade-net script"
+        ${POST_UPGRADE_DIR}/post-upgrade-net.sh >> ${LOG} 2>&1
+        test $? == 0 && msg_done || msg_fail
+    fi
 }
 
 case "$1" in

--- a/board/common/overlay/etc/init.d/S79postupgradeapp
+++ b/board/common/overlay/etc/init.d/S79postupgradeapp
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+POST_UPGRADE_DIR="/usr/share/post-upgrade"
 POST_UPGRADE_APP_SCHEDULED="/data/.post-upgrade-app-scheduled"
 
 LOG="/var/log/post-upgrade.log"
@@ -7,7 +8,7 @@ LOG="/var/log/post-upgrade.log"
 
 test -n "${OS_VERSION}" || source /etc/init.d/base
 
-test -s ${POST_UPGRADE_APP_SCHEDULED} || exit 0
+test -f ${POST_UPGRADE_APP_SCHEDULED} || exit 0
 
 function run_post_upgrade() {
     for script in $(cat ${POST_UPGRADE_APP_SCHEDULED}); do
@@ -15,6 +16,12 @@ function run_post_upgrade() {
         ${script} >> ${LOG} 2>&1
         test $? == 0 && msg_done || msg_fail
     done
+
+    if [[ -x "${POST_UPGRADE_DIR}/post-upgrade-app.sh" ]]; then
+        msg_begin "Running common post-upgrade-app script"
+        ${POST_UPGRADE_DIR}/post-upgrade-app.sh >> ${LOG} 2>&1
+        test $? == 0 && msg_done || msg_fail
+    fi
 }
 
 case "$1" in


### PR DESCRIPTION
All the `-net` and `-app` post-upgrade scripts are currently run regardless of their version. This fixes the issue by ensuring only higher equal versions are run.
